### PR TITLE
Fix license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,15 @@ name = "pybalboa"
 version = "1.0.1"
 description = "Module to communicate with a Balboa spa wifi adapter."
 authors = ["Nathan Spencer <natekspencer@gmail.com>","Tim Rightnour <root@garbled.net>"]
-license = "Apache 2.0"
 readme = "README.rst"
 homepage = "https://github.com/garbled1/pybalboa"
 repository = "https://github.com/garbled1/pybalboa"
 keywords = ["Balboa", "spa", "hot tub", "asynchronous"]
 include = ["pybalboa/py.typed"]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+]
+
 
 [tool.poetry.dependencies]
 python = "^3.8.1"


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)